### PR TITLE
サービス名変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# <img src="src/site/images/icon-transparent.png" height=26> 企業テックブログRSS
-企業のテックブログの更新をまとめたRSSフィードを配信しています。  
-記事を読んでその企業の技術・カルチャーを知れることや、質の高い技術情報を得られることを目的としています。
+# <img src="src/site/images/icon-transparent.png" height=26> 必要の部屋 ~企業テックブログRSS~
+必要の部屋は企業のテックブログの更新をまとめたRSSフィードを配信しています。  
+記事を読んでその企業の技術・カルチャーを知れることや、質の高い技術情報を得られることを目的とし、slackと連携することを前提としています。  
+あなたにとって必要な情報が得られますように。
 
 https://cami-crane.github.io/tech-blog-rss-feed/  
 
@@ -8,10 +9,8 @@ https://cami-crane.github.io/tech-blog-rss-feed/
 
 ## サイト追加の方針
 企業のテックブログ（技術ブログ、エンジニアブログ）であれば、基本的には追加します。  
-所属企業で運営してるため、記事の内容は勝手に変更されることがあります。
-
-## サイトの追加方法
-[src/resources/feed-info-list.ts](https://github.com/yamadashy/tech-blog-rss-feed/blob/main/src/resources/feed-info-list.ts) で管理しており、その一覧にない場合 issue を作っていただければ対応します。  
+所属企業で運営してるため、記事の内容は勝手に変更されることがあります。  
+需要があればフロントエンドやバックエンド、デザインなどの領域に特化したまとめフィードを作成する予定です。
 
 ### プルリクでの送り方
 もしプルリクを送っていただける場合は以下のように作成できます。

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -5,12 +5,12 @@ module.exports = {
   // サイト設定
   siteUrl: `${siteUrl}`,
   siteUrlStem: siteUrlStem,
-  siteTitle: '企業テックブログRSS',
+  siteTitle: '必要の部屋',
   siteDescription:
     '企業のテックブログの更新をまとめたRSSフィードを配信しています。記事を読んでその企業の技術・カルチャーを知れることや、質の高い技術情報を得られることを目的としています。',
 
   // フィード設定
-  feedTitle: '企業テックブログRSS',
+  feedTitle: '必要の部屋',
   feedDescription: '企業のテックブログの更新をまとめたRSSフィード',
   feedLanguage: 'ja',
   feedCopyright: 'cami-crane/tech-blog-rss-feed',

--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -565,7 +565,6 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['現場サポート', 'https://support.genbasupport.com/techblog/feed/'],
   ['虎の穴', 'https://toranoana-lab.hatenablog.com/feed'],
   ['遊舎工房', 'https://blog.yushakobo.jp/feed'],
-  ['電通国際情報サービス', 'https://tech.isid.co.jp/feed'],
   ['食べチョク', 'https://tech.tabechoku.com/feed'],
   ['食べログ', 'https://tech-blog.tabelog.com/feed'],
   ['ＦＦＲＩセキュリティ', 'https://engineers.ffri.jp/feed'],
@@ -573,10 +572,11 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
 
 /**
  * その他候補
- *
- * RSSがなくなった。復活したら入れたい
- * https://blog.gmo.media/
- * https://orenda.co.jp/bloglist/
+*
+* RSSがなくなった。復活したら入れたい
+* https://blog.gmo.media/
+* https://orenda.co.jp/bloglist/
+['電通国際情報サービス', 'https://tech.isid.co.jp/feed'],
  *
  * リニューアルされてフィードが消えたのでしばらくしたら確認
  * ['DMM', 'https://inside.dmm.com/feed'],


### PR DESCRIPTION
## 変更
- サービス名を「必要の部屋」に変更
- 電通国際サービスがRSSフィードを廃止したようなのでコメントアウト